### PR TITLE
Add `sd_product` tag to auto-gen pr. layout

### DIFF
--- a/layouts/auto_generated_product.tpl
+++ b/layouts/auto_generated_product.tpl
@@ -7,6 +7,8 @@
   {% include "html-head" product_page: true %}
   {% include "edicy-tools-variables" %}
   {% include "common-page-variables" %}
+
+  {% sd_product %}
 </head>
 
 <body class="item-page product-page content-page{% if site.search.enabled %} search-enabled{% endif %}{% if editmode or site.has_many_languages? %} lang-enabled{% endif %} {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}">


### PR DESCRIPTION
Include `sd_product` tag in Auto-rendered Product layout to render out product structured data.

Closes #165 